### PR TITLE
fix: 廃止された attribute を適切な attribute に置き換える

### DIFF
--- a/roles/common/tasks/common_rhel8.yml
+++ b/roles/common/tasks/common_rhel8.yml
@@ -99,5 +99,5 @@
      dest=/root/.bashrc
      line="HISTTIMEFORMAT='%Y-%m-%dT%T%z '"
 
-- include: host_change.yml
-- include: etckeeper_commit.yml
+- import_tasks: host_change.yml
+- import_tasks: etckeeper_commit.yml

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-- include: common_rhel8.yml
+- include_tasks: common_rhel8.yml
   when:
     - ansible_facts['distribution_major_version'] == "7" or ansible_facts['distribution_major_version'] == "8" 
  
-- include: common_rhel9.yml
+- include_tasks: common_rhel9.yml
   when:
     - ansible_facts['distribution_major_version'] == "9"

--- a/roles/minimum/httpd/tasks/main.yml
+++ b/roles/minimum/httpd/tasks/main.yml
@@ -23,7 +23,7 @@
     - mpm.conf
     - security.conf
 
-- include: security.yml
+- import_tasks: security.yml
 
 - name: start apache
   systemd:

--- a/target.yml.example
+++ b/target.yml.example
@@ -7,7 +7,7 @@
   roles:
     - common
     - tigervnc
-    - jmeter55
+    - jmeter56
     #- python-scripts
     #- minimum/httpd
     - phpjmadmin
@@ -19,6 +19,6 @@
   become: yes
   roles:
     - common
-    - jmeter55
+    - jmeter56
     - jmeter-worker
     #- reboot


### PR DESCRIPTION
## 概要
- include の attribute が廃止されたので、適切な attribute に置換
- テンプレートの JMeter バージョンを変更

## 補足
none