### PR TITLE
fix: WorkFow ファイルのインデントミスを修正

### DIFF
--- a/.github/workflows/terraform-format-check.yml
+++ b/.github/workflows/terraform-format-check.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-    - name: Set up Terraform
-      uses: hashicorp/setup-terraform@v3
-      with:
-        terraform_version: 1.9.0
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.0
 
       - name: Format check
         run: terraform fmt -no-color -check -diff -recursive


### PR DESCRIPTION
## 概要
- 「Terraform format check」 WF 内の 「Set up Terraform step」 のインデントミスを修正